### PR TITLE
fixed mismatch in supported data types between the python api client and

### DIFF
--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PythonClientCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/PythonClientCodegen.java
@@ -39,6 +39,7 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
         languageSpecificPrimitives.add("bool");
         languageSpecificPrimitives.add("str");
         languageSpecificPrimitives.add("datetime");
+        languageSpecificPrimitives.add("dict");
 
         typeMapping.clear();
         typeMapping.put("integer", "int");
@@ -46,7 +47,8 @@ public class PythonClientCodegen extends DefaultCodegen implements CodegenConfig
         typeMapping.put("long", "int");
         typeMapping.put("double", "float");
         typeMapping.put("array", "list");
-        typeMapping.put("map", "map");
+        typeMapping.put("map", "dict");
+        typeMapping.put("object", "dict");
         typeMapping.put("boolean", "bool");
         typeMapping.put("string", "str");
         typeMapping.put("date", "datetime");


### PR DESCRIPTION
the serializers created by generator, adding support for generic maps

This is a stopgap until our swagger api is version 2.0 compliant and can declare `additionalProperties`.  I have no idea if codegen even has full support for the swagger 2.0 spec, but we'll find out soon enough, I'm sure.